### PR TITLE
getting-started instructions for postgresql-server-dev package

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,6 +23,11 @@ sudo apt-get install nodejs
 ````bash
 sudo apt-get install postgresql
 # it should now be running, no need to start it if everything went well
+
+psql --version
+# note the first two digits in the version number from the response and insert in the next command
+sudo apt-get install postgresql-server-dev-XX.XX
+
 ````
 
 ## Installing Redis


### PR DESCRIPTION
getting started is missing a required apt package. This PR adds instructions for installing that package.
